### PR TITLE
Cria ping a cada 5 minutos

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+require('./ping');
+
 const express = require('express')
 const cors = require('cors')
 const swaggerUi = require('swagger-ui-express')
@@ -8,6 +10,7 @@ const productsRouter = require('./server/routes/ProductsRouter')
 const ordersRouter = require('./server/routes/OrdersRouter')
 const usersRouter = require('./server/routes/UsersRouter')
 const internalRouter = require('./server/routes/InternalRouter')
+const healthcheckRouter = require('./server/routes/Healthcheck')
 
 const app = express()
 const port = process.env.PORT || 3000 
@@ -21,6 +24,7 @@ app.use('/products', productsRouter);
 app.use('/orders', ordersRouter);
 app.use('/users', usersRouter);
 app.use('/internal', internalRouter);
+app.use('/healthcheck', healthcheckRouter);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
@@ -31,3 +35,4 @@ app.use('*', (req, res) => {
 app.listen(port, () => {
   console.log(`Example app listening at http://localhost:${port}`)
 })
+

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express": "^4.17.1",
     "express-rate-limit": "^6.4.0",
     "jsonwebtoken": "^8.5.1",
+    "node-fetch": "^2.6.7",
     "path": "^0.12.7",
     "sequelize": "^6.3.5",
     "sequelize-cli": "^6.2.0",

--- a/ping.js
+++ b/ping.js
@@ -1,0 +1,24 @@
+const fetch = require('node-fetch');
+
+const URL = (() => {
+    const urls = {
+        development: 'http://localhost:3000',
+        production: 'https://lab-api-bq.onrender.com'
+    };
+
+    const env = process.env.NODE_ENV || 'production';
+    return urls[env];
+})();
+
+const toMinutes = (time) => time * 1000 * 60; 
+const interval = toMinutes(5);
+
+const ping = async() => {
+    try {
+        await fetch(`${URL}/healthcheck/ping`);
+    } catch (err) {
+        console.log('Could not ping', err)
+    }
+};
+
+setInterval(ping, interval);

--- a/server/controller/HealthcheckController.js
+++ b/server/controller/HealthcheckController.js
@@ -1,0 +1,7 @@
+const ping = (req, res) => {
+    res.send('pong');
+}
+
+module.exports = {
+    ping
+}

--- a/server/routes/Healthcheck.js
+++ b/server/routes/Healthcheck.js
@@ -1,0 +1,8 @@
+const { Router } = require('express');
+const router = Router();
+
+const controller = require('../controller/HealthcheckController');
+
+router.get('/ping', controller.ping);
+
+module.exports = router;


### PR DESCRIPTION
Cria uma rota de `/healthcheck/ping` só pra responder `pong` e um arquivo de `ping` que fica pingando essa rota a cada 5 minutos.

A ideia é evitar que a aplicação "desligue", já que alguns hosts (como Heroku e Render) fazem isso caso a aplicação fique inativa após alguns minutos.